### PR TITLE
package.json: Change tesseract.js to use specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "request": "^2.88.0",
     "screenshot-desktop": "^1.8.0",
     "seek-bzip": "^1.0.5",
-    "tesseract.js": "^2.0.0-alpha.11",
+    "tesseract.js": "2.0.0-alpha.11",
     "twig": "^1.13.3"
   },
   "config": {


### PR DESCRIPTION
Since TesseractWorker is deprecated in more recent versions.

More info here:
https://github.com/naptha/tesseract.js/issues/346#issuecomment-540514740